### PR TITLE
Change the telemetry_chrome_hangs pig to also collect late writes.

### DIFF
--- a/src/main/pig/telemetry_chrome_hangs.pig
+++ b/src/main/pig/telemetry_chrome_hangs.pig
@@ -9,11 +9,18 @@ SET pig.logfile telemetry-chrome-hangs.log;
 SET mapred.compress.map.output true;
 SET mapred.map.output.compression.codec org.apache.hadoop.io.compress.SnappyCodec;
 
+define IsMap com.mozilla.pig.filter.map.IsMap();
+define Size com.mozilla.pig.eval.Size();
+
 raw = LOAD 'hbase://telemetry' USING com.mozilla.pig.load.HBaseMultiScanLoader('$start_date', '$end_date', 'yyyyMMdd', 'data:json') AS (k:chararray, json:chararray);
-genmap = FOREACH raw GENERATE k,json,com.mozilla.pig.eval.json.JsonMap(json) AS json_map:map[];
-filtered_genmap = FILTER genmap BY json_map#'chromeHangs' IS NOT NULL AND 
-                                   com.mozilla.pig.eval.Size(json_map#'chromeHangs') > 0 AND
-                                   json_map#'info'#'appUpdateChannel' == 'nightly' AND
-                                   json_map#'info'#'OS' == 'WINNT';
-orig_data = FOREACH filtered_genmap GENERATE k,json;
-STORE orig_data INTO 'chrome-hangs-$start_date-$end_date';
+
+genmap = FOREACH raw GENERATE com.mozilla.pig.eval.json.JsonMap(json) AS json_map:map[];
+
+with_hangs  = FILTER genmap BY json_map#'chromeHangs' IS NOT NULL AND IsMap(json_map#'chromeHangs') AND json_map#'chromeHangs'#'memoryMap' IS NOT NULL AND Size(json_map#'chromeHangs'#'memoryMap') > 0;
+with_writes = FILTER genmap BY json_map#'lateWrites'  IS NOT NULL AND IsMap(json_map#'lateWrites') AND json_map#'lateWrites'#'memoryMap'  IS NOT NULL AND Size(json_map#'lateWrites'#'memoryMap') > 0;
+
+the_hangs  = FOREACH with_hangs  GENERATE TOMAP('chromeHangs', json_map#'chromeHangs', 'addons', json_map#'info'#'addons');
+the_writes = FOREACH with_writes GENERATE TOMAP('lateWrites',  json_map#'lateWrites', 'addons', json_map#'info'#'addons');
+
+all_of_it = UNION the_hangs, the_writes;
+STORE all_of_it INTO 'chrome-hangs-$start_date-$end_date';


### PR DESCRIPTION
Things to note:
- My first pig file. It is probably "wrong".
- This selects only new format pig files.
- It outputs the result as a pig map, so the python script also has to be
  updated. Sending this first so that we can do the review in parallel.
- It switches to a white list of fields to massively reduce the size of the
  data that is output. Right now the only additional data is the addon list.
- If a ping has both a hang and a late write, it gets split. I think this is
  fine. I is hard to see what extra benefit we would get from knowing that a
  single ping had a hang and a late write.
