### PR TITLE
Change the telemetry_chrome_hangs pig to also collect late writes.

### DIFF
--- a/src/main/pig/telemetry_chrome_hangs.pig
+++ b/src/main/pig/telemetry_chrome_hangs.pig
@@ -9,11 +9,21 @@ SET pig.logfile telemetry-chrome-hangs.log;
 SET mapred.compress.map.output true;
 SET mapred.map.output.compression.codec org.apache.hadoop.io.compress.SnappyCodec;
 
+define IsMap com.mozilla.pig.filter.map.IsMap();
+define Size com.mozilla.pig.eval.Size();
+
 raw = LOAD 'hbase://telemetry' USING com.mozilla.pig.load.HBaseMultiScanLoader('$start_date', '$end_date', 'yyyyMMdd', 'data:json') AS (k:chararray, json:chararray);
+
 genmap = FOREACH raw GENERATE k,json,com.mozilla.pig.eval.json.JsonMap(json) AS json_map:map[];
-filtered_genmap = FILTER genmap BY json_map#'chromeHangs' IS NOT NULL AND 
-                                   com.mozilla.pig.eval.Size(json_map#'chromeHangs') > 0 AND
-                                   json_map#'info'#'appUpdateChannel' == 'nightly' AND
-                                   json_map#'info'#'OS' == 'WINNT';
+
+filtered_genmap = FILTER genmap BY (json_map#'chromeHangs' IS NOT NULL
+                                    AND IsMap(json_map#'chromeHangs')
+                                    AND json_map#'chromeHangs'#'memoryMap' IS NOT NULL
+                                    AND Size(json_map#'chromeHangs'#'memoryMap') > 0)
+                                OR (json_map#'lateWrites' IS NOT NULL
+                                    AND IsMap(json_map#'lateWrites')
+                                    AND json_map#'lateWrites'#'memoryMap' IS NOT NULL
+                                    AND Size(json_map#'lateWrites'#'memoryMap') > 0);
+
 orig_data = FOREACH filtered_genmap GENERATE k,json;
 STORE orig_data INTO 'chrome-hangs-$start_date-$end_date';


### PR DESCRIPTION
This is a very reduced version of the other pull request. Given the bug
in com.mozilla.pig.eval.json.JsonMap, we cannot currently write its output,
so this pull request keeps the current setup of writing the original json.
